### PR TITLE
Ensuring that Pipfile.lock is up to date.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
       before_install: cd backend
       install:
         - pip install pipenv
-        - pipenv install --dev
+        - pipenv install --dev --deploy
       script:
         - black src/ --check
         - pylint src/ -E


### PR DESCRIPTION
Using `--deploy` in `pipenv install` to ensure that `Pipfile.lock` is up to date