### PR TITLE
Faster docker build

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,6 +1,5 @@
-FROM node:12.2.0-alpine
+FROM node:13.7.0-alpine
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
-COPY frontend/package.json /app/package.json
-COPY frontend/package-lock.json /app/package-lock.json
-RUN npm install
+COPY frontend /app
+RUN npm install node-sass

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,8 +28,6 @@ services:
     container_name: 'mongo'
     image: 'mongo'
     restart: always
-    volumes:
-      - ./mongo-volume:/data/db
     ports:
       - '27017-27019:27017-27019'
     environment:
@@ -44,9 +42,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.frontend
-    volumes:
-      - '../frontend:/app'
-      - '/app/node_modules'
     ports:
       - "82:82"
     environment:


### PR DESCRIPTION
- Node moduled are now directly copied from frontend directory to reduce installation time;
- DB volume has been deleted as storage is unnecessary for development.
closes #92 